### PR TITLE
Add alternative native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ## Description
 Little piece of Python code to find out candidate Netflix's Open Connect Appliances (OCA) for the end-host running this script.
 We rely on Netflix's speed-test fast.com, which measures throughput between users and their allocated OCAs.
-The script is two-fold: 
-1. It gets the token necessary to request the list of OCAs.  
+The script is two-fold:
+1. It gets the token necessary to request the list of OCAs.
 2. It requests the list of OCAs by inserting the token on the request.
 
 For more info: https://medium.com/netflix-techblog/building-fast-com-4857fe0f8adb
@@ -29,3 +29,24 @@ $ sudo apt-get install curl
 python get_ocas.py
 ```
 
+
+# Nim implementation
+
+- Compiles to single-file native binary without dependencies, similar to C/C++ executables.
+
+#### Requisites
+
+- Nim http://nim-lang.org
+- In addition, you may need to install `whois` (wont need `curl`).
+
+```
+$ sudo apt-get install whois
+```
+
+#### Compile
+
+- `nim compile -d:ssl -d:release get_ocas.nim`
+
+#### Run
+
+- `./get_ocas` (Just run it on terminal window).

--- a/get_ocas.nim
+++ b/get_ocas.nim
@@ -1,0 +1,29 @@
+import osproc, json, httpclient, strutils, re, nativesockets
+
+let requests = newHttpClient()
+
+proc get_host_isp_information() =
+  ## This function call Netflix's API to get the list of candidates OCAs for the user running the script.
+  const url = "https://api.ipify.org"
+  let
+    ipaddr = requests.getContent(url).strip()  # Get IP address.
+    host_isp_information = execProcess("whois -h whois.cymru.com ' -v " & ipaddr & "'") # whois.
+  echo "#".repeat(99), "\n> Host IP information\n", host_isp_information
+
+proc request_for_oca() =
+  ## This function call Netflix's API to get the list of candidates OCAs for the user running the script.
+  const
+    url = "https://fast.com/app-ed402d.js"
+    query = "https://api.fast.com/netflix/speedtest?https=true&token="
+  let  # Run command to get TOKEN from FAST.com API
+    token = findAll(requests.getContent(url), re"""token:"(.+)",urlCount""")[0][7..^11]
+    oca_list = parseJson(requests.getContent(query & token)) # JSON with OCA.
+  echo "#".repeat(99), "\n> Allocated OCAs for this user"
+  for oca in oca_list: echo oca["url"].getStr  # Echo the URLs to stdout.
+  echo "#".repeat(99), "\n> IP address of the allocated OCAs"
+  for oca in oca_list: echo getHostByName(oca["url"].getStr.split('/')[2]).addrList[0] # Echo the IPs to stdout.
+
+
+when isMainModule:
+  get_host_isp_information()
+  request_for_oca()


### PR DESCRIPTION
- Make it work again, alternative native implementation.
- `python2` implementation wont work for me, so was less time to just re-write it than troubleshoot the old code.
- Wont need `curl`.
- We can send the info with this implementation so was useful, so I share the code.

:slightly_smiling_face: 
