### PR TITLE
dockerfile: remove uv.lock from copy list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Copy project files
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 COPY src/ ./src/
 
 # Install dependencies and build the package

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 # Copy project files
 COPY pyproject.toml ./
+COPY LICENSE ./
 COPY src/ ./src/
 
 # Install dependencies and build the package

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 # Copy project files
 COPY pyproject.toml ./
-COPY LICENSE ./
+COPY LICENSE README.md ./
 COPY src/ ./src/
 
 # Install dependencies and build the package


### PR DESCRIPTION
uv.lock not present in repository.
Without this fix docker wont build:
› 0.0s
     => CACHED [builder 4/7] WORKDIR /app
    0.0s
     => ERROR [builder 5/7] COPY pyproject.toml uv.lock ./
    0.0s
    ------
     > [builder 5/7] COPY pyproject.toml uv.lock ./:
    ------
    Dockerfile:23
    --------------------
      21 |
      22 |     # Copy project files
      23 | >>> COPY pyproject.toml uv.lock ./
      24 |     COPY src/ ./src/
      25 |
    --------------------
    ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref 09b46075-aec4-44c7-9048-b7ecb3037ab9::48ez1o0jtymiqe66zzk0uc48a: "/uv.lock": not found

P.S. Adding also newline at end of repo as linters hate lack of it.
