### PR TITLE
fix: preserve 0.0 coordinates and use timezone-aware timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,43 @@ than list every change.
 ### Added
 
 - Python 3.14 to the CI matrix and the package classifiers.
+- Regression tests for coordinates of exactly 0.0 and for timezone-aware
+  timestamps, covering both defects below. Test coverage rose from 24% to 31%
+  (`utils/mapping.py` 27% → 88%, `utils/formatters.py` 18% → 68%).
+
+### Fixed
+
+- **Coordinates of exactly 0.0 were silently discarded** from maps and exports
+  ([#9]). `latitude`/`longitude` are `float | None` with `None` meaning
+  "unknown", but ten call sites tested them for truthiness, so `0.0` was treated
+  as absent: the OCA vanished from the generated map and its coordinate was
+  written as an empty cell in CSV and XLSX. Latitude 0.0 is the equator, but
+  **longitude 0.0 is the prime meridian through Greenwich**, so a London OCA was
+  a realistic trigger. All ten sites now test `is not None`. Verified that no
+  geocoding path uses `0.0` as an "unknown" sentinel — `-1.0` is the placeholder,
+  guarded separately in `HybridGeocodeService._is_good_result`.
+
+### Changed
+
+- **`datetime.utcnow()` replaced with `datetime.now(timezone.utc)`** ([#22]). The
+  old call is deprecated and scheduled for removal, and returned a *naive*
+  datetime that was UTC only by convention.
+
+  **This changes export output.** `PublicIPInfo.timestamp` and
+  `OCALocatorResult.query_time` are now timezone-aware, so `isoformat()` emits an
+  explicit offset:
+
+  - JSON `query_time` / `timestamp`: `2026-08-30T16:00:00` →
+    `2026-08-30T16:00:00+00:00`
+  - CSV `query_time` column: same change
+
+  The XLSX and Markdown exports are **unaffected** — they format with
+  `strftime("%Y-%m-%d %H:%M:%S UTC")`, which ignores tzinfo and already stated
+  UTC explicitly. If you parse the JSON or CSV timestamps downstream with a
+  naive-datetime assumption, this is a breaking change.
+
+[#9]: https://github.com/estcarisimo/Netflix-OCA-Servers-Locator/issues/9
+[#22]: https://github.com/estcarisimo/Netflix-OCA-Servers-Locator/issues/22
 
 ### Changed
 

--- a/src/netflix_oca_locator/core/models.py
+++ b/src/netflix_oca_locator/core/models.py
@@ -7,9 +7,25 @@ used throughout the application.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field, HttpUrl, IPvAnyAddress, field_validator
+
+
+def _utc_now() -> datetime:
+    """
+    Return the current time as a timezone-aware UTC datetime.
+
+    Replaces ``datetime.utcnow()``, which is deprecated and scheduled for removal
+    and returned a naive datetime. Timestamps serialised with ``isoformat()`` now
+    carry an explicit ``+00:00`` offset instead of being implicitly UTC.
+
+    Returns
+    -------
+    datetime
+        Current time, timezone-aware, in UTC.
+    """
+    return datetime.now(timezone.utc)
 
 
 class PublicIPInfo(BaseModel):
@@ -32,7 +48,7 @@ class PublicIPInfo(BaseModel):
     """
 
     ip: IPvAnyAddress
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=_utc_now)
 
 
 class ISPInfo(BaseModel):
@@ -199,7 +215,7 @@ class OCALocatorResult(BaseModel):
     public_ip: PublicIPInfo
     isp_info: ISPInfo
     oca_servers: list[OCAServer]
-    query_time: datetime = Field(default_factory=datetime.utcnow)
+    query_time: datetime = Field(default_factory=_utc_now)
     fast_com_token: str = Field(..., description="Fast.com API token")
 
 

--- a/src/netflix_oca_locator/utils/formatters.py
+++ b/src/netflix_oca_locator/utils/formatters.py
@@ -111,8 +111,9 @@ class ResultFormatter:
                     "ip_address": str(oca.ip_address),
                     "city": oca.city or "",
                     "iata_code": oca.iata_code or "",
-                    "latitude": oca.latitude or "",
-                    "longitude": oca.longitude or "",
+                    # `or ""` would turn a valid 0.0 into an empty cell.
+                    "latitude": oca.latitude if oca.latitude is not None else "",
+                    "longitude": oca.longitude if oca.longitude is not None else "",
                     "asn": oca.asn or "",
                     "geocoding_provider": oca.geocoding_provider or "",
                     "geolocation_approach": oca.geolocation_approach or "",
@@ -179,8 +180,8 @@ class ResultFormatter:
                         "IP Address": str(oca.ip_address),
                         "City": oca.city or "",
                         "IATA Code": oca.iata_code or "",
-                        "Latitude": oca.latitude or "",
-                        "Longitude": oca.longitude or "",
+                        "Latitude": oca.latitude if oca.latitude is not None else "",
+                        "Longitude": oca.longitude if oca.longitude is not None else "",
                         "ASN": oca.asn or "",
                         "Geocoding Provider": oca.geocoding_provider or "",
                         "Geolocation Method": oca.geolocation_approach or "",
@@ -251,7 +252,7 @@ class ResultFormatter:
                 iata = oca.iata_code or "-"
                 coords = (
                     f"{oca.latitude:.4f}, {oca.longitude:.4f}"
-                    if oca.latitude and oca.longitude
+                    if oca.latitude is not None and oca.longitude is not None
                     else "-"
                 )
 
@@ -286,7 +287,7 @@ class ResultFormatter:
                     md_content.append(f"- **City:** {oca.city}")
                 if oca.iata_code:
                     md_content.append(f"- **IATA Code:** {oca.iata_code}")
-                if oca.latitude and oca.longitude:
+                if oca.latitude is not None and oca.longitude is not None:
                     md_content.append(f"- **Coordinates:** {oca.latitude:.6f}, {oca.longitude:.6f}")
 
                 md_content.append("")

--- a/src/netflix_oca_locator/utils/mapping.py
+++ b/src/netflix_oca_locator/utils/mapping.py
@@ -62,8 +62,13 @@ class MapGenerator:
             output_dir.mkdir(parents=True, exist_ok=True)
             output_path = output_dir / "oca_locations_map.html"
 
-        # Get OCAs with coordinates
-        located_ocas = [oca for oca in result.oca_servers if oca.latitude and oca.longitude]
+        # Get OCAs with coordinates. Test against None rather than truthiness:
+        # 0.0 is a valid coordinate (the equator and the prime meridian).
+        located_ocas = [
+            oca
+            for oca in result.oca_servers
+            if oca.latitude is not None and oca.longitude is not None
+        ]
 
         if not located_ocas:
             logger.warning("No OCAs with location data found, creating empty map")
@@ -115,8 +120,8 @@ class MapGenerator:
             return (39.8283, -98.5795)
 
         # Calculate average position
-        lats = [oca.latitude for oca in ocas if oca.latitude]
-        lons = [oca.longitude for oca in ocas if oca.longitude]
+        lats = [oca.latitude for oca in ocas if oca.latitude is not None]
+        lons = [oca.longitude for oca in ocas if oca.longitude is not None]
 
         if lats and lons:
             return (sum(lats) / len(lats), sum(lons) / len(lons))
@@ -152,7 +157,7 @@ class MapGenerator:
         oca : OCAServer
             OCA server to add.
         """
-        if not (oca.latitude and oca.longitude):
+        if oca.latitude is None or oca.longitude is None:
             return
 
         # Create popup content
@@ -196,7 +201,9 @@ class MapGenerator:
         # Add lines connecting all OCAs (showing the CDN network)
         if len(ocas) > 1:
             coordinates = [
-                [oca.latitude, oca.longitude] for oca in ocas if oca.latitude and oca.longitude
+                [oca.latitude, oca.longitude]
+                for oca in ocas
+                if oca.latitude is not None and oca.longitude is not None
             ]
 
             # Create a subtle network visualization

--- a/tests/test_core/test_timestamps.py
+++ b/tests/test_core/test_timestamps.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for timezone-aware timestamps.
+
+The models used to default to `datetime.utcnow()`, which is deprecated, scheduled
+for removal, and returned a *naive* datetime that was UTC only by convention.
+They now use `datetime.now(timezone.utc)`, which is explicit.
+
+That changes serialised output: `isoformat()` gains a `+00:00` offset. These
+tests pin that format so it cannot drift again unnoticed.
+
+See https://github.com/estcarisimo/Netflix-OCA-Servers-Locator/issues/22.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from netflix_oca_locator.config.settings import Settings
+from netflix_oca_locator.core.models import OCALocatorResult, PublicIPInfo
+from netflix_oca_locator.utils.formatters import ResultFormatter
+
+
+class TestTimestampsAreAware:
+    """Default timestamps must carry explicit UTC tzinfo."""
+
+    def test_public_ip_timestamp_is_aware(self):
+        info = PublicIPInfo(ip="203.0.113.1")
+        assert info.timestamp.tzinfo is not None
+        assert info.timestamp.utcoffset() == timezone.utc.utcoffset(None)
+
+    def test_query_time_is_aware(self, mock_public_ip, mock_isp_info, mock_oca_servers):
+        result = OCALocatorResult(
+            public_ip=mock_public_ip,
+            isp_info=mock_isp_info,
+            oca_servers=mock_oca_servers,
+            fast_com_token="tz_token",
+        )
+        assert result.query_time.tzinfo is not None
+        assert result.query_time.utcoffset() == timezone.utc.utcoffset(None)
+
+    def test_no_deprecation_warning_on_construction(self, recwarn):
+        """`datetime.utcnow()` raises a DeprecationWarning on modern Pythons."""
+        PublicIPInfo(ip="203.0.113.2")
+
+        offenders = [w for w in recwarn.list if "utcnow" in str(w.message)]
+        assert not offenders, f"utcnow deprecation warning raised: {offenders}"
+
+
+class TestSerialisedFormat:
+    """The exported string format is a contract; pin it."""
+
+    def test_isoformat_carries_utc_offset(self):
+        info = PublicIPInfo(ip="203.0.113.3")
+        rendered = info.timestamp.isoformat()
+        assert rendered.endswith("+00:00"), rendered
+
+    def test_json_export_timestamps_are_offset_qualified(
+        self, mock_oca_result, temp_export_dir, tz_settings
+    ):
+        out = temp_export_dir / "tz.json"
+        ResultFormatter(tz_settings).export_json(mock_oca_result, out)
+
+        data = json.loads(out.read_text())
+        assert data["query_time"].endswith("+00:00")
+        assert data["public_ip"]["timestamp"].endswith("+00:00")
+
+        # Round-trips back to an aware datetime.
+        parsed = datetime.fromisoformat(data["query_time"])
+        assert parsed.tzinfo is not None
+
+    def test_markdown_still_labels_utc_explicitly(
+        self, mock_oca_result, temp_export_dir, tz_settings
+    ):
+        """
+        The Markdown and XLSX exports format with `strftime('... UTC')`, which
+        ignores tzinfo. Those must stay byte-identical to before the change.
+        """
+        out = temp_export_dir / "tz.md"
+        ResultFormatter(tz_settings).export_markdown(mock_oca_result, out)
+
+        content = out.read_text()
+        expected = mock_oca_result.query_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+        assert expected in content
+        assert "+00:00" not in content
+
+
+@pytest.fixture
+def tz_settings():
+    """Settings for export."""
+    return Settings(debug=True)

--- a/tests/test_utils/test_null_island.py
+++ b/tests/test_utils/test_null_island.py
@@ -1,0 +1,139 @@
+"""
+Regression tests for coordinates of exactly 0.0.
+
+`latitude` and `longitude` are `float | None`, with `None` meaning "unknown" and
+0.0 a perfectly valid coordinate: the equator, and the prime meridian that runs
+through Greenwich. Every consumer used to test them for truthiness, which
+silently dropped an OCA at 0.0 from maps and wrote an empty cell into exports.
+
+See https://github.com/estcarisimo/Netflix-OCA-Servers-Locator/issues/9.
+"""
+
+import csv
+import json
+
+import pytest
+
+from netflix_oca_locator.config.settings import Settings
+from netflix_oca_locator.core.models import OCALocatorResult, OCAServer
+from netflix_oca_locator.utils.formatters import ResultFormatter
+from netflix_oca_locator.utils.mapping import MapGenerator
+
+
+@pytest.fixture
+def null_island_oca():
+    """An OCA sitting exactly at 0.0, 0.0."""
+    return OCAServer(
+        domain="zero.nflxvideo.net",
+        ip_address="198.45.48.9",
+        url="https://zero.nflxvideo.net/speedtest",
+        city="Null Island",
+        iata_code="NUL",
+        latitude=0.0,
+        longitude=0.0,
+    )
+
+
+@pytest.fixture
+def greenwich_oca():
+    """A realistic case: a London OCA on the prime meridian, longitude 0.0."""
+    return OCAServer(
+        domain="lhr1.nflxvideo.net",
+        ip_address="198.45.48.10",
+        url="https://lhr1.nflxvideo.net/speedtest",
+        city="London, UK",
+        iata_code="LHR",
+        latitude=51.4779,
+        longitude=0.0,
+    )
+
+
+@pytest.fixture
+def zero_result(mock_public_ip, mock_isp_info, null_island_oca, greenwich_oca):
+    """A result whose OCAs all have at least one zero coordinate."""
+    return OCALocatorResult(
+        public_ip=mock_public_ip,
+        isp_info=mock_isp_info,
+        oca_servers=[null_island_oca, greenwich_oca],
+        fast_com_token="test_token_zero",
+    )
+
+
+class TestZeroCoordinatesInExports:
+    """Zero coordinates must survive every export format."""
+
+    def test_json_keeps_zero(self, zero_result, temp_export_dir, settings):
+        out = temp_export_dir / "zero.json"
+        ResultFormatter(settings).export_json(zero_result, out)
+
+        data = json.loads(out.read_text())
+        ocas = {o["domain"]: o for o in data["oca_servers"]}
+
+        assert ocas["zero.nflxvideo.net"]["latitude"] == 0.0
+        assert ocas["zero.nflxvideo.net"]["longitude"] == 0.0
+        assert ocas["lhr1.nflxvideo.net"]["longitude"] == 0.0
+
+    def test_csv_writes_zero_not_empty_string(self, zero_result, temp_export_dir, settings):
+        out = temp_export_dir / "zero.csv"
+        ResultFormatter(settings).export_csv(zero_result, out)
+
+        rows = {r["domain"]: r for r in csv.DictReader(out.open())}
+
+        # The bug wrote "" here because `0.0 or ""` evaluates to "".
+        assert rows["zero.nflxvideo.net"]["latitude"] == "0.0"
+        assert rows["zero.nflxvideo.net"]["longitude"] == "0.0"
+        assert rows["lhr1.nflxvideo.net"]["longitude"] == "0.0"
+
+    def test_markdown_renders_zero_coordinates(self, zero_result, temp_export_dir, settings):
+        out = temp_export_dir / "zero.md"
+        ResultFormatter(settings).export_markdown(zero_result, out)
+
+        content = out.read_text()
+        # Previously rendered as "-" because of the truthiness check.
+        assert "0.0000, 0.0000" in content
+        assert "51.4779, 0.0000" in content
+
+
+class TestZeroCoordinatesOnMap:
+    """Zero coordinates must not be dropped from the map."""
+
+    def test_map_includes_zero_coordinate_ocas(self, zero_result, temp_export_dir, settings):
+        out = temp_export_dir / "zero_map.html"
+        MapGenerator(settings).create_oca_map(zero_result, out)
+
+        content = out.read_text()
+        # Both OCAs should have produced markers.
+        assert "zero.nflxvideo.net" in content
+        assert "lhr1.nflxvideo.net" in content
+
+
+class TestNoneStillMeansUnknown:
+    """The fix must not make None look like a real coordinate."""
+
+    def test_none_coordinates_still_omitted(
+        self, mock_public_ip, mock_isp_info, temp_export_dir, settings
+    ):
+        unlocated = OCAServer(
+            domain="unknown.nflxvideo.net",
+            ip_address="198.45.48.11",
+            url="https://unknown.nflxvideo.net/speedtest",
+        )
+        result = OCALocatorResult(
+            public_ip=mock_public_ip,
+            isp_info=mock_isp_info,
+            oca_servers=[unlocated],
+            fast_com_token="test_token_none",
+        )
+
+        out = temp_export_dir / "none.csv"
+        ResultFormatter(settings).export_csv(result, out)
+
+        row = next(iter(csv.DictReader(out.open())))
+        assert row["latitude"] == ""
+        assert row["longitude"] == ""
+
+
+@pytest.fixture
+def settings():
+    """Settings for export and map generation."""
+    return Settings(debug=True)


### PR DESCRIPTION
Closes #9. Closes #22.

Both were deferred from the repo-hygiene work as behavioural changes needing their own reviewable commit. Each lands with regression tests **verified to fail against the unfixed code** — a regression test that passes either way is worthless, so both suites were run against reverted source to prove they catch the defect.

## #9 — coordinates of exactly 0.0 were silently discarded

`latitude`/`longitude` are `float | None`, with `None` meaning "unknown" and `ge=-90`/`ge=-180` explicitly permitting `0.0`. But ten call sites tested them for *truthiness*, so a valid `0.0` was treated as absent: the OCA vanished from the generated map, and its coordinate was written as an empty cell in CSV and XLSX.

Latitude `0.0` is the equator in the Gulf of Guinea — irrelevant for an OCA. **Longitude `0.0` is the prime meridian through Greenwich**, so a London OCA was a realistic trigger.

All ten sites now test `is not None`:
- `mapping.py:66,118,155,199`
- `formatters.py:114,115,182,183,254,289`

**The trap the issue warned about, checked:** a naive fix would regress if any geocoding path returned `0.0` to mean "unknown". It does not — `-1.0` is the placeholder, guarded separately in `HybridGeocodeService._is_good_result`. JSON export was never affected either, since it passes the value straight through without `or ""`.

## #22 — `datetime.utcnow()` is deprecated and scheduled for removal

Replaced with `datetime.now(timezone.utc)` behind a documented `_utc_now` helper.

### ⚠️ This changes export output

Timestamps are now timezone-aware, so `isoformat()` emits an explicit offset:

| Export | Before | After |
| --- | --- | --- |
| JSON `query_time`, `timestamp` | `2026-08-30T16:00:00` | `2026-08-30T16:00:00+00:00` |
| CSV `query_time` | same | same |
| XLSX, Markdown | `2026-08-30 16:00:00 UTC` | **unchanged** |

XLSX and Markdown are unaffected because they format with `strftime("%Y-%m-%d %H:%M:%S UTC")`, which ignores tzinfo and already stated UTC explicitly. There's a test pinning that, so the two paths can't silently diverge.

Anything parsing the JSON or CSV timestamps as naive datetimes will need updating. That's the deliberate trade: the old value was UTC only by convention, and the function it relied on is going away.

## Verification

- Tests **22 → 33**; coverage **24% → 31%** (`mapping.py` 27% → 88%, `formatters.py` 18% → 68%)
- Against unfixed source: **3/5** coordinate tests and **4/6** timestamp tests fail, with the map logging `No OCAs with location data found, creating empty map` for two OCAs that both had valid coordinates
- `ruff check` / `ruff format --check` clean; full suite green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)